### PR TITLE
Junk url

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-junklet (2.0.0)
+    rspec-junklet (2.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rspec/junklet/junk.rb
+++ b/lib/rspec/junklet/junk.rb
@@ -119,7 +119,7 @@ module RSpec
           when :bool
             generator = -> { [true, false].sample }
           when :url
-            generator = -> { "http://gargage.dumpster" }
+            generator = -> { "http://#{::SecureRandom.uuid}.com" }
           when Array, Enumerable
             generator = -> { type.to_a.sample }
           when Proc

--- a/lib/rspec/junklet/junk.rb
+++ b/lib/rspec/junklet/junk.rb
@@ -1,4 +1,5 @@
 require_relative 'formatter'
+require 'securerandom'
 
 module RSpec
   module Junklet
@@ -117,6 +118,8 @@ module RSpec
             generator = -> { rand(max-min) + min }
           when :bool
             generator = -> { [true, false].sample }
+          when :url
+            generator = -> { "http://gargage.dumpster" }
           when Array, Enumerable
             generator = -> { type.to_a.sample }
           when Proc
@@ -136,7 +139,7 @@ module RSpec
           # junk. Get (size+1)/2 chars, which will be correct for even
           # sizes and 1 char too many for odds, so trim off with
           # [0...size] (note three .'s to trim off final char)
-          SecureRandom.hex((size+1)/2)[0...size]
+          ::SecureRandom.hex((size+1)/2)[0...size]
         end
       end
     end

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -140,8 +140,7 @@ describe RSpec::Junklet do
 
     context "with type: :url" do
       let(:junk_url) { junk :url }
-      specify { expect { URI.parse(junk_url) }.to_not raise(URI::InvalidURIError) }
-      specify { expect(junk_url).to eq("http://garbage.dumpster") }
+      specify { expect { URI.parse(junk_url) }.not_to raise_error(URI::InvalidURIError) }
     end
 
     # begin

--- a/spec/lib/rspec/examples_spec.rb
+++ b/spec/lib/rspec/examples_spec.rb
@@ -138,6 +138,12 @@ describe RSpec::Junklet do
       end
     end
 
+    context "with type: :url" do
+      let(:junk_url) { junk :url }
+      specify { expect { URI.parse(junk_url) }.to_not raise(URI::InvalidURIError) }
+      specify { expect(junk_url).to eq("http://garbage.dumpster") }
+    end
+
     # begin
     #   $caught_bad_junklet_error = false
     #   junklet :cheesy_bad_junklet, cheese: true


### PR DESCRIPTION
Simple junk urls.

Lots of ways to extend this through options:
- add query strings
- protocol changes
- change TLD
- prepend subdomains
