### PR TITLE
Less secure, more fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,15 +95,11 @@ hex string 32 bytes long.
 
 ### integer
 
-Give junk an integer argument and it will return that many hexadecimal digits of
-junk data. Note that this is HALF the number of digits returned if you were to
-call `SecureRandom.hex(n)`, because `hex(n)` returns n _bytes_, each of which
-requires two hex digits to represent. Since we're more concerned about specific
-byte lengths, `junk(n)` gives you n digits, not n*2 digits representing n bytes.
-
+Give junk an integer argument and it will return that many characters of Base64
+encoded junk data.
 
 ```ruby
-junk 17 - return 17 bytes of junk data
+junk 17 - return a String of junk data with length 17
 ```
 
 ### symbol

--- a/lib/rspec/junklet/junk.rb
+++ b/lib/rspec/junklet/junk.rb
@@ -3,6 +3,7 @@ require_relative 'formatter'
 module RSpec
   module Junklet
     module Junk
+      PRNG = Random.new
       def junk(*args)
         # TODO: It's long past time to extract this....
 
@@ -114,7 +115,7 @@ module RSpec
 
             min,max = max,min if min>max
 
-            generator = -> { rand(max-min) + min }
+            generator = -> { PRNG.rand(max-min) + min }
           when :bool
             generator = -> { [true, false].sample }
           when Array, Enumerable
@@ -131,12 +132,11 @@ module RSpec
           val
         else
           size = args.first.is_a?(Numeric) ? args.first : 32
-          # hex returns size*2 digits, because it returns a 0..255 byte
-          # as a hex pair. But when we want junt, we want *bytes* of
-          # junk. Get (size+1)/2 chars, which will be correct for even
-          # sizes and 1 char too many for odds, so trim off with
-          # [0...size] (note three .'s to trim off final char)
-          SecureRandom.hex((size+1)/2)[0...size]
+          # Random#bytes encoded as Base64 will be about 1.5 times longer than
+          # needed. We trim it down to the requested length. (This also removes
+          # the newline and any equal signs used to pad the end of the Base64
+          # data.
+          [PRNG.bytes(size)].pack('m')[0...size]
         end
       end
     end

--- a/script/benchmark/secure_random-vs-random.rb
+++ b/script/benchmark/secure_random-vs-random.rb
@@ -1,0 +1,26 @@
+require 'benchmark/ips'
+
+require 'securerandom'
+
+size = 32
+
+PRNG = Random.new
+
+Benchmark.ips do |x|
+  x.report('securerandom') do
+    SecureRandom.hex((size+1)/2)[0...size]
+  end
+  x.report('random') do
+    [PRNG.bytes(size)].pack('m')[0...size]
+  end
+end
+
+__END__
+
+ruby script/benchmark/secure_random-vs-random.rb
+Calculating -------------------------------------
+  securerandom    17.843k i/100ms
+        random    30.491k i/100ms
+-------------------------------------------------
+  securerandom    265.681k (± 6.4%) i/s - 1.338M
+        random    472.108k (± 9.1%) i/s - 2.348M

--- a/spec/lib/rspec/junklet/junk_spec.rb
+++ b/spec/lib/rspec/junklet/junk_spec.rb
@@ -9,9 +9,9 @@ end
 
 describe JunkSpy do
   let(:junk) { subject.junk }
-  let(:hex_regex) { /^[0-9a-f]+$/ }
+  let(:base64_regex) { %r(\A[0-9a-z+/]+\z)i }
 
-  specify { expect(junk).to match(hex_regex) }
+  specify { expect(junk).to match(base64_regex) }
   specify { expect(junk.size).to eq(32) }
 
   specify "it is random each time" do
@@ -21,7 +21,7 @@ describe JunkSpy do
   describe "#junk(size)" do
     let(:junk) { subject.junk 14 }
 
-    specify { expect(junk).to match(hex_regex) }
+    specify { expect(junk).to match(base64_regex) }
     specify { expect(junk.size).to eq(14) }
   end
 

--- a/spec/lib/rspec/junklet/junklet_spec.rb
+++ b/spec/lib/rspec/junklet/junklet_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require PROJECT_ROOT + 'lib/rspec/junklet/junklet'
 
 class JunkletSpy


### PR DESCRIPTION
SecureRandom gets cryptographically strong random data from the operating system. This gem doesn't require high-quality randomness.

This also changes the junk string to Base64-encoded data rather than hexadecimal digits. The result is more unique strings at a given size.

The Base64 character set might be problematic in some usage.

```
0-9 a-z A-Z + /
```

For instance a random URL `"http://#{junk}.com"` might be `'http://GJ/8ZtRt.com'`.
